### PR TITLE
Use own workflow and gpt-4o model

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -11,10 +11,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Code Review
-        uses: freeedcom/ai-codereviewer@main
+        uses: nunesmatheus/ai-codereviewer@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_MODEL: "gpt-4-1106-preview"
+          OPENAI_API_MODEL: "gpt-4o"
           exclude: "yarn.lock,dist/**"


### PR DESCRIPTION
- Update the code review workflow to use this repository instead of the original forked one
- Sets the model to gpt-4o as it is much more cost effective
